### PR TITLE
TD-845: optimize memory

### DIFF
--- a/src/main/java/dev/vality/reporter/service/impl/LocalReportCreatorServiceImpl.java
+++ b/src/main/java/dev/vality/reporter/service/impl/LocalReportCreatorServiceImpl.java
@@ -11,6 +11,7 @@ import dev.vality.reporter.util.FormatUtil;
 import dev.vality.reporter.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -26,6 +27,7 @@ import java.time.ZoneId;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+@Slf4j
 @Setter
 @Service
 @RequiredArgsConstructor
@@ -48,7 +50,9 @@ public class LocalReportCreatorServiceImpl implements ReportCreatorService<Local
 
     @Override
     public void createReport(LocalReportCreatorDto reportCreatorDto) throws IOException {
+        log.info("Start create report {}", reportCreatorDto.getReport().getId());
         try (SXSSFWorkbook wb = new SXSSFWorkbook(100)) {
+            wb.setCompressTempFiles(true);
             Sheet sh = createSheet(wb);
             AtomicInteger rownum = new AtomicInteger(0);
 
@@ -64,6 +68,7 @@ public class LocalReportCreatorServiceImpl implements ReportCreatorService<Local
             wb.write(reportCreatorDto.getOutputStream());
             reportCreatorDto.getOutputStream().close();
             wb.dispose();
+            log.info("Report {} were created", reportCreatorDto.getReport().getId());
         }
     }
 

--- a/src/main/java/dev/vality/reporter/template/LocalPaymentRegistryTemplateImpl.java
+++ b/src/main/java/dev/vality/reporter/template/LocalPaymentRegistryTemplateImpl.java
@@ -11,6 +11,7 @@ import dev.vality.reporter.service.PartyService;
 import dev.vality.reporter.service.ReportCreatorService;
 import dev.vality.reporter.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.Cursor;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LocalPaymentRegistryTemplateImpl implements ReportTemplate {
@@ -41,6 +43,7 @@ public class LocalPaymentRegistryTemplateImpl implements ReportTemplate {
     @Override
     public void processReportTemplate(Report report, OutputStream outputStream) throws
             IOException {
+        log.info("Start process report template {}", report.getId());
         String partyId = report.getPartyId();
         String shopId = report.getPartyShopId();
         LocalDateTime fromTime = report.getFromTime();
@@ -74,6 +77,7 @@ public class LocalPaymentRegistryTemplateImpl implements ReportTemplate {
                     .build();
 
             localReportCreatorService.createReport(reportCreatorDto);
+            log.info("Report template {} were processed", report.getId());
         }
     }
 }


### PR DESCRIPTION
SXSSF POI в памяти держит по сто строк, и сразу сбрасывает их в файл, но при записи книги эксель POI создает временные файлы формата xml, которые очень много весят (например для файла xlsx, который в итоге 30Мб, временные xml во время записи в сумме больше гига). SXSSF POI умеет сжимать временные файлы, указала, чтобы файлы сжимались, тогда они нормально весят, вроде вылетать по памяти при таких параметрах не должно(протестировала около 2млн строк, все норм отработало). 