### PR TITLE
fix amount in minor units + fix status for different adjustment

### DIFF
--- a/src/main/java/dev/vality/reporter/model/AdjustmentType.java
+++ b/src/main/java/dev/vality/reporter/model/AdjustmentType.java
@@ -1,0 +1,17 @@
+package dev.vality.reporter.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AdjustmentType {
+    CHANGE_AMOUNT("amount"),
+    CHANGE_STATUS("status");
+
+
+    private final String value;
+
+
+}

--- a/src/main/java/dev/vality/reporter/model/AdjustmentType.java
+++ b/src/main/java/dev/vality/reporter/model/AdjustmentType.java
@@ -10,8 +10,5 @@ public enum AdjustmentType {
     CHANGE_AMOUNT("amount"),
     CHANGE_STATUS("status");
 
-
     private final String value;
-
-
 }

--- a/src/test/java/dev/vality/reporter/report/PaymentRegistryTemplateTest.java
+++ b/src/test/java/dev/vality/reporter/report/PaymentRegistryTemplateTest.java
@@ -199,7 +199,7 @@ class PaymentRegistryTemplateTest {
 
             Row adjustmentsFirstRow = sheet.getRow(18);
             assertEquals("id0", adjustmentsFirstRow.getCell(0).getStringCellValue());
-            assertEquals(123, adjustmentsFirstRow.getCell(3).getNumericCellValue());
+            assertEquals("1.23", adjustmentsFirstRow.getCell(3).getStringCellValue());
             assertEquals("payment_external_id", adjustmentsFirstRow.getCell(10).getStringCellValue());
             assertEquals(captured.getLiteral(), adjustmentsFirstRow.getCell(11).getStringCellValue());
         } finally {


### PR DESCRIPTION
Надо учитывать какой статус у платежа в зависимости от корректировки.

Если в корректировке изменилась сумма, то отдаем изначальный статус платежа. 
Если изменился статус, отдаем новый статус, который пришел для инвойса в event.
Если были обе корректировки, то надо учесть, что статус для корректировки суммы должен быть тем же, что и у изначального платежа, а при корректировки статуса - обновленный статус инвойса. 

Решил заложиться на поле reason. Других маркеров в текущей реализации не нашел. 
Есть еще вариант добавить поле в adjustment, которое будет строго определять тип корректировки. Но как будто это оверхед. 
